### PR TITLE
[ASSIGNMENT] 6차 과제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/org/sopt/Main.java
+++ b/src/main/java/org/sopt/Main.java
@@ -2,8 +2,10 @@ package org.sopt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Main {
   public static void main(String[] args) {
     SpringApplication.run(Main.class, args);

--- a/src/main/java/org/sopt/config/BlacklistedTokenCleanupScheduler.java
+++ b/src/main/java/org/sopt/config/BlacklistedTokenCleanupScheduler.java
@@ -1,0 +1,22 @@
+package org.sopt.config;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.sopt.repository.BlacklistedAccessTokenRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class BlacklistedTokenCleanupScheduler {
+
+  private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
+
+  @Scheduled(cron = "0 0 0 * * *")
+  @Transactional
+  public void deletedExpiredTokens() {
+    blacklistedAccessTokenRepository.deleteByExpiresAtBefore(LocalDateTime.now());
+  }
+
+}

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
-import org.sopt.domain.BlacklistedAccessToken;
 import org.sopt.repository.BlacklistedAccessTokenRepository;
 import org.sopt.service.JwtService;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/org/sopt/config/JwtAuthFilter.java
+++ b/src/main/java/org/sopt/config/JwtAuthFilter.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import org.sopt.domain.BlacklistedAccessToken;
+import org.sopt.repository.BlacklistedAccessTokenRepository;
 import org.sopt.service.JwtService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,6 +23,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
   private final JwtService jwtService;
+  private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
 
   @Override
   protected void doFilterInternal(
@@ -32,6 +35,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     if (header != null && header.startsWith("Bearer ")) {
       String token = header.substring("Bearer ".length()).trim();
       try {
+        if (blacklistedAccessTokenRepository.existsByToken(token)) {
+          response.setStatus((HttpServletResponse.SC_UNAUTHORIZED));
+          return;
+        }
+
         Long userId = jwtService.verifyAndGetUserId(token);
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
             String.valueOf(userId), null, Collections.emptyList());

--- a/src/main/java/org/sopt/config/KakaoClient.java
+++ b/src/main/java/org/sopt/config/KakaoClient.java
@@ -1,0 +1,48 @@
+package org.sopt.config;
+
+import org.sopt.dto.response.KakaoTokenResponse;
+import org.sopt.dto.response.KakaoUserInfoResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoClient {
+
+  private final RestClient restClient = RestClient.create();
+
+  @Value("${oauth.kakao.client-id}")
+  private String clientId;
+
+  @Value("${oauth.kakao.client-secret}")
+  private String clientSecret;
+
+  @Value("${oauth.kakao.redirect-uri}")
+  private String redirectUri;
+
+  @Value("${oauth.kakao.token-uri}")
+  private String tokenUri;
+
+  @Value("${oauth.kakao.user-info-uri}")
+  private String userInfoUri;
+
+  public KakaoTokenResponse getToken(String code) {
+    return restClient.post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body("grant_type=authorization_code" + "&client_id=" + clientId + "&redirect_uri=" + redirectUri + "&code=" + code + "&client_secret=" + clientSecret)
+        .retrieve()
+        .body(KakaoTokenResponse.class);
+  }
+
+  public KakaoUserInfoResponse getUserInfo(String KakaoAccessToken) {
+    return restClient.get()
+        .uri(userInfoUri)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + KakaoAccessToken)
+        .retrieve()
+        .body(KakaoUserInfoResponse.class);
+  }
+
+}

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -36,5 +38,10 @@ public class SecurityConfig {
         )
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 }

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/signup").permitAll()
+            .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/signup", "/api/v1/auth/kakao/callback").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/**").permitAll()
             .requestMatchers(HttpMethod.POST, "/posts").authenticated()
             .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
+            .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue", "/api/v1/auth/signup").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/**").permitAll()
             .requestMatchers(HttpMethod.POST, "/posts").authenticated()
             .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()

--- a/src/main/java/org/sopt/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.sopt.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -24,7 +25,12 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/v1/login", "/v1/reissue").permitAll()
+            .requestMatchers("/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
+            .requestMatchers(HttpMethod.GET, "/posts/**").permitAll()
+            .requestMatchers(HttpMethod.POST, "/posts").authenticated()
+            .requestMatchers(HttpMethod.PUT, "/posts/**").authenticated()
+            .requestMatchers(HttpMethod.DELETE, "/posts/**").authenticated()
+            .requestMatchers(HttpMethod.PATCH, "/posts/*/likes").authenticated()
             .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
             .anyRequest().authenticated()
         )

--- a/src/main/java/org/sopt/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/config/SwaggerConfig.java
@@ -1,6 +1,10 @@
 package org.sopt.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
@@ -11,7 +15,18 @@ public class SwaggerConfig {
 
   @Bean
   public OpenAPI openAPI() {
+    String securitySchemeName = "JWT";
+
     return new OpenAPI()
+        .components(new Components()
+                .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                    .name(securitySchemeName)
+                    .type(Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT")
+                )
+        )
+        .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
         .servers(List.of(
             new Server().url("/")
         ));

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -80,4 +80,13 @@ public class AuthController {
     authService.logout(userId, accessToken);
     return ResponseEntity.ok(ApiResponse.onSuccess(null));
   }
+
+  @Operation(summary = "카카오 로그인 콜백", description = "카카오 로그인 후 리다이렉트되는 콜백 엔드포인트입니다. 카카오에서 전달된 인가 코드를 받아 로그인 처리를 합니다.")
+  @GetMapping("/kakao/callback")
+  public ResponseEntity<ApiResponse<TokenResponse>> kakaoCallback(
+      @RequestParam("code") String code
+  ) {
+    TokenResponse tokens = authService.kakaoLogin(code);
+    return ResponseEntity.ok(ApiResponse.onSuccess(tokens));
+  }
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -7,12 +7,14 @@ import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
 import org.sopt.service.AuthService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -65,5 +67,17 @@ public class AuthController {
   ) {
     TokenResponse tokens = authService.reissue(refreshToken);
     return ResponseEntity.ok(ApiResponse.onSuccess(tokens));
+  }
+
+  @Operation(summary = "로그아웃 (Access Token 블랙리스트 등록)")
+  @PostMapping("/logout")
+  public ResponseEntity<ApiResponse<Void>> logout(
+      Authentication authentication,
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader
+  ) {
+    Long userId = Long.parseLong(authentication.getName());
+    String accessToken = authorizationHeader.substring("Bearer ".length()).trim();
+    authService.logout(userId, accessToken);
+    return ResponseEntity.ok(ApiResponse.onSuccess(null));
   }
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
   }
 
   @Operation(summary = "내 정보 조회 (Access Token 검증)")
-  @GetMapping("/api/v1/me")
+  @GetMapping("/me")
   public ResponseEntity<ApiResponse<UserResponse>> me(Authentication authentication) {
 
     if (authentication == null || authentication.getPrincipal() == null) {

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,6 +1,7 @@
 package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.sopt.dto.request.SignUpRequest;
 import org.sopt.dto.response.ApiResponse;
@@ -54,7 +55,7 @@ public class AuthController {
   @Operation(summary = "회원가입")
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<UserResponse>> signUp(
-      @RequestBody SignUpRequest request
+      @Valid @RequestBody SignUpRequest request
   ) {
     UserResponse user = authService.signUp(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(user));

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -2,14 +2,17 @@ package org.sopt.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.sopt.dto.request.SignUpRequest;
 import org.sopt.dto.response.ApiResponse;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
 import org.sopt.service.AuthService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +47,23 @@ public class AuthController {
     UserResponse user = authService.getUserById(userId);
 
     return ResponseEntity.ok(ApiResponse.onSuccess(user));
+  }
+
+  @Operation(summary = "회원가입")
+  @PostMapping("/signup")
+  public ResponseEntity<ApiResponse<UserResponse>> signUp(
+      @RequestBody SignUpRequest request
+  ) {
+    UserResponse user = authService.signUp(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(user));
+  }
+
+  @Operation(summary = "Access Token 재발급")
+  @PostMapping("/reissue")
+  public ResponseEntity<ApiResponse<TokenResponse>> reissue(
+      @RequestParam("refreshToken") String refreshToken
+  ) {
+    TokenResponse tokens = authService.reissue(refreshToken);
+    return ResponseEntity.ok(ApiResponse.onSuccess(tokens));
   }
 }

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.domain.BoardType;
-import org.sopt.domain.Post;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
 import org.sopt.dto.response.ApiResponse;
@@ -30,7 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-//@Tag(name = "Post", description =  = "게시글 관련 API")
+@Tag(name = "Post", description = "게시글 관련 API")
 @RestController
 @RequestMapping("/posts")
 public class PostController {

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -18,6 +18,7 @@ import org.sopt.service.LikeService;
 import org.sopt.service.PostService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -51,9 +52,12 @@ public class PostController {
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
   })
   public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
-      @RequestBody CreatePostRequest request
+      @RequestBody CreatePostRequest request,
+      Authentication authentication
   ) {
-    CreatePostResponse response = postService.createPost(request);
+    Long userId = Long.parseLong(authentication.getName());
+
+    CreatePostResponse response = postService.createPost(request, userId);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(SuccessStatus.POST_CREATED, response));
   }
 
@@ -105,9 +109,12 @@ public class PostController {
   public ResponseEntity<ApiResponse<PostResponse>> updatePost(
       @Parameter(description = "수정할 게시글 ID", example = "1")
       @PathVariable Long id,
-      @RequestBody UpdatePostRequest request
+      @RequestBody UpdatePostRequest request,
+      Authentication authentication
   ) {
-    PostResponse response = postService.updatePost(id, request);
+    Long userId = Long.parseLong(authentication.getName());
+
+    PostResponse response = postService.updatePost(id, request, userId);
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of(SuccessStatus.POST_UPDATED, response));
   }
 
@@ -121,9 +128,12 @@ public class PostController {
   })
   public ResponseEntity<ApiResponse<PostResponse>> deletePost(
       @Parameter(description = "삭제할 게시글 ID", example = "1")
-      @PathVariable Long id
+      @PathVariable Long id,
+      Authentication authentication
   ) {
-    PostResponse response = postService.deletePost(id);
+    Long userId = Long.parseLong(authentication.getName());
+
+    PostResponse response = postService.deletePost(id, userId);
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of(SuccessStatus.POST_DELETED, response));
   }
 
@@ -137,8 +147,9 @@ public class PostController {
   public ResponseEntity<ApiResponse<LikeResponse>> toggleLike(
       @Parameter(description = "좋아요/취소할 게시글 ID", example = "1")
       @PathVariable Long postId,
-      @RequestParam Long userId
+      Authentication authentication
   ) {
+    Long userId = Long.parseLong(authentication.getName());
     LikeResponse response = likeService.toggleLike(postId, userId);
     SuccessStatus status = response.isLiked() ? SuccessStatus.LIKE_CREATED : SuccessStatus.LIKE_DELETED;
     return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.of(status, response));

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.sopt.domain.BoardType;
 import org.sopt.dto.request.CreatePostRequest;
 import org.sopt.dto.request.UpdatePostRequest;
@@ -51,7 +52,7 @@ public class PostController {
       @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다.")
   })
   public ResponseEntity<ApiResponse<CreatePostResponse>> createPost(
-      @RequestBody CreatePostRequest request,
+      @Valid @RequestBody CreatePostRequest request,
       Authentication authentication
   ) {
     Long userId = Long.parseLong(authentication.getName());
@@ -108,7 +109,7 @@ public class PostController {
   public ResponseEntity<ApiResponse<PostResponse>> updatePost(
       @Parameter(description = "수정할 게시글 ID", example = "1")
       @PathVariable Long id,
-      @RequestBody UpdatePostRequest request,
+      @Valid @RequestBody UpdatePostRequest request,
       Authentication authentication
   ) {
     Long userId = Long.parseLong(authentication.getName());

--- a/src/main/java/org/sopt/domain/BaseTimeEntity.java
+++ b/src/main/java/org/sopt/domain/BaseTimeEntity.java
@@ -3,10 +3,12 @@ package org.sopt.domain;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
@@ -16,12 +18,4 @@ public abstract class BaseTimeEntity {
 
   @LastModifiedDate
   private LocalDateTime updatedAt;
-
-  public LocalDateTime getCreatedAt() {
-    return createdAt;
-  }
-
-  public LocalDateTime getUpdatedAt() {
-    return updatedAt;
-  }
 }

--- a/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
+++ b/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,7 @@ public class BlacklistedAccessToken {
   @Column(nullable = false)
   private LocalDateTime expiresAt;
 
+  @Builder
   private BlacklistedAccessToken(String token, Long userId, LocalDateTime expiresAt) {
     this.token = token;
     this.userId = userId;
@@ -35,6 +37,10 @@ public class BlacklistedAccessToken {
   }
 
   public static BlacklistedAccessToken of(String token, Long userId, LocalDateTime expiresAt) {
-    return new BlacklistedAccessToken(token, userId, expiresAt);
+    return BlacklistedAccessToken.builder()
+        .token(token)
+        .userId(userId)
+        .expiresAt(expiresAt)
+        .build();
   }
 }

--- a/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
+++ b/src/main/java/org/sopt/domain/BlacklistedAccessToken.java
@@ -1,0 +1,40 @@
+package org.sopt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlacklistedAccessToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true, length = 1000)
+  private String token;
+
+  @Column(nullable = false)
+  private Long userId;
+
+  @Column(nullable = false)
+  private LocalDateTime expiresAt;
+
+  private BlacklistedAccessToken(String token, Long userId, LocalDateTime expiresAt) {
+    this.token = token;
+    this.userId = userId;
+    this.expiresAt = expiresAt;
+  }
+
+  public static BlacklistedAccessToken of(String token, Long userId, LocalDateTime expiresAt) {
+    return new BlacklistedAccessToken(token, userId, expiresAt);
+  }
+}

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -8,8 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "likes")
 public class Like extends BaseTimeEntity {
 
@@ -27,9 +33,8 @@ public class Like extends BaseTimeEntity {
 
   private boolean isLiked;
 
-  protected Like() {}
-
-  public Like(User user, Post post) {
+  @Builder
+  private Like(User user, Post post) {
     this.user = user;
     this.post = post;
     this.isLiked = true;
@@ -37,21 +42,5 @@ public class Like extends BaseTimeEntity {
 
   public void toggle() {
     this.isLiked = !this.isLiked;
-  }
-
-  public boolean isLiked() {
-    return isLiked;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public User getUser() {
-    return user;
-  }
-
-  public Post getPost() {
-    return post;
   }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -7,8 +7,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity  // "이 클래스를 DB 테이블과 매핑해요" — 영속성 컨텍스트가 이 클래스를 관리해요
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
 
   @Id // 앞에서 배운 PK
@@ -27,9 +33,8 @@ public class Post extends BaseTimeEntity {
   private boolean isAnonymous;
   private BoardType boardType;
 
-  protected Post() {}  // JPA 기본 생성자
-
-  public Post(String title, String content, User user, boolean isQuestion, boolean isAnonymous, BoardType boardType) {
+  @Builder
+  private Post(String title, String content, User user, boolean isQuestion, boolean isAnonymous, BoardType boardType) {
     this.title = title;
     this.content = content;
     this.user = user;
@@ -45,28 +50,5 @@ public class Post extends BaseTimeEntity {
     this.isAnonymous = isAnonymous;
   }
 
-  public Long getId() {
-    return this.id;
-  }
-
-  public String getTitle() {
-    return this.title;
-  }
-
-  public String getContent() {
-    return this.content;
-  }
-
-  public BoardType getBoardType() {
-    return this.boardType;
-  }
-
   public String getAuthor() { return this.user.getNickname(); }
-
-  public boolean isAnonymous() { return this.isAnonymous; }
-
-  public boolean isQuestion() { return this.isQuestion; }
-
-  public User getUser() { return this.user; }
-
 }

--- a/src/main/java/org/sopt/domain/RefreshToken.java
+++ b/src/main/java/org/sopt/domain/RefreshToken.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,6 +29,7 @@ public class RefreshToken {
   @Column(nullable = false)
   private LocalDateTime expiresAt;
 
+  @Builder
   private RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
     this.userId = userId;
     this.token = token;
@@ -35,11 +37,11 @@ public class RefreshToken {
   }
 
   public static RefreshToken of(Long userId, String token, long expiresInSeconds) {
-    return new RefreshToken(
-        userId,
-        token,
-        LocalDateTime.now().plusSeconds(expiresInSeconds)
-    );
+    return RefreshToken.builder()
+        .userId(userId)
+        .token(token)
+        .expiresAt(LocalDateTime.now().plusSeconds(expiresInSeconds))
+        .build();
   }
 
   public void rotate(String newToken, long expiresInSeconds) {

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -5,8 +5,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")  // "user"는 SQL 예약어라 테이블명을 변경해요
 public class User { //extends BaseTimeEntity {
 
@@ -24,27 +30,12 @@ public class User { //extends BaseTimeEntity {
 
   private String providerId;
 
-  protected User() {}
-
-  public User(String nickname, String email, String password, String provider, String providerId) {
+  @Builder
+  private User(String nickname, String email, String password, String provider, String providerId) {
     this.nickname = nickname;
     this.email = email;
     this.password = password;
     this.provider = provider;
     this.providerId = providerId;
   }
-
-  public Long getId() {
-    return this.id;
-  }
-
-  public String getNickname() {
-    return this.nickname;
-  }
-
-  public String getEmail() {
-    return this.email;
-  }
-
-  public String getPassword() { return this.password; }
 }

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -20,12 +20,18 @@ public class User { //extends BaseTimeEntity {
 
   private String password;
 
+  private String provider;
+
+  private String providerId;
+
   protected User() {}
 
-  public User(String nickname, String email, String password) {
+  public User(String nickname, String email, String password, String provider, String providerId) {
     this.nickname = nickname;
     this.email = email;
     this.password = password;
+    this.provider = provider;
+    this.providerId = providerId;
   }
 
   public Long getId() {

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -22,9 +22,10 @@ public class User { //extends BaseTimeEntity {
 
   protected User() {}
 
-  public User(String nickname, String email) {
+  public User(String nickname, String email, String password) {
     this.nickname = nickname;
     this.email = email;
+    this.password = password;
   }
 
   public Long getId() {

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -1,6 +1,9 @@
 package org.sopt.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.sopt.domain.BoardType;
 
 // 게시글 작성 요청 (클라이언트 → 서버)
@@ -8,6 +11,8 @@ import org.sopt.domain.BoardType;
 public record CreatePostRequest(
 
   @Schema(description = "게시글 제목", example = "오늘 학식 뭐임")
+  @NotBlank(message = "제목은 필수입니다.")
+  @Size(max = 50, message = "제목은 최대 50자까지 입력 가능합니다.")
   String title,
 
   @Schema(description = "게시글 내용", example = "돈까스래")
@@ -23,6 +28,7 @@ public record CreatePostRequest(
   boolean isAnonymous,
 
   @Schema(description = "게시판 타입", example = "FREE")
+  @NotNull(message = "게시판 타입은 필수입니다.")
   BoardType boardType
 ) {
 }

--- a/src/main/java/org/sopt/dto/request/CreatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/CreatePostRequest.java
@@ -6,8 +6,6 @@ import org.sopt.domain.BoardType;
 // 게시글 작성 요청 (클라이언트 → 서버)
 @Schema(description = "게시글 작성 요청")
 public record CreatePostRequest(
-  @Schema(description = "작성자 ID", example = "1")
-  Long userId,
 
   @Schema(description = "게시글 제목", example = "오늘 학식 뭐임")
   String title,

--- a/src/main/java/org/sopt/dto/request/SignUpRequest.java
+++ b/src/main/java/org/sopt/dto/request/SignUpRequest.java
@@ -1,0 +1,8 @@
+package org.sopt.dto.request;
+
+public record SignUpRequest(
+    String nickname,
+    String email,
+    String password
+) {
+}

--- a/src/main/java/org/sopt/dto/request/SignUpRequest.java
+++ b/src/main/java/org/sopt/dto/request/SignUpRequest.java
@@ -13,6 +13,7 @@ public record SignUpRequest(
     String nickname,
 
     @Schema(description = "이메일", example = "seopseopt@sopt.com")
+    @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
 

--- a/src/main/java/org/sopt/dto/request/SignUpRequest.java
+++ b/src/main/java/org/sopt/dto/request/SignUpRequest.java
@@ -1,8 +1,23 @@
 package org.sopt.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청")
 public record SignUpRequest(
+
+    @Schema(description = "닉네임", example = "섭섭이")
+    @NotBlank(message = "닉네임은 필수입니다.")
     String nickname,
+
+    @Schema(description = "이메일", example = "seopseopt@sopt.com")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
+
+    @Schema(description = "비밀번호", example = "password123")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     String password
 ) {
 }

--- a/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
+++ b/src/main/java/org/sopt/dto/request/UpdatePostRequest.java
@@ -1,11 +1,15 @@
 package org.sopt.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "게시글 수정 요청")
 public record UpdatePostRequest(
 
   @Schema(description = "수정할 제목", example = "수정된 제목")
+  @NotBlank(message = "제목은 필수입니다.")
+  @Size(max = 50, message = "제목은 최대 50자까지 입력 가능합니다.")
   String title,
 
   @Schema(description = "수정할 내용", example = "수정된 내용입니다.")

--- a/src/main/java/org/sopt/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/org/sopt/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+    @JsonProperty("access_token")
+    String accessToken,
+
+    @JsonProperty("token_type")
+    String tokenType,
+
+    @JsonProperty("refresh_token")
+    String refreshToken,
+
+    @JsonProperty("expires_in")
+    int expiresIn
+) {
+}

--- a/src/main/java/org/sopt/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/org/sopt/dto/response/KakaoUserInfoResponse.java
@@ -1,7 +1,6 @@
 package org.sopt.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Properties;
 
 public record KakaoUserInfoResponse(
     Long id,

--- a/src/main/java/org/sopt/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/org/sopt/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Properties;
+
+public record KakaoUserInfoResponse(
+    Long id,
+
+    @JsonProperty("kakao_account")
+    KakaoAccount kakaoAccount,
+
+    Properties properties
+) {
+  public record KakaoAccount(
+      String email
+  ) {
+  }
+
+  public record Properties(
+      String nickname
+  ) {
+  }
+}

--- a/src/main/java/org/sopt/dto/response/PostResponse.java
+++ b/src/main/java/org/sopt/dto/response/PostResponse.java
@@ -14,12 +14,12 @@ public record PostResponse(
   BoardType boardType
 ) {
 
-  public PostResponse(Post post) {
-    this(
+  public static PostResponse from(Post post) {
+    return new PostResponse(
       post.getId(),
       post.getTitle(),
       post.getContent(),
-      post.getAuthor(),
+      post.isAnonymous() ? "익명" : post.getAuthor(),
       post.getCreatedAt().toString(),
       post.isAnonymous(),
       post.isQuestion(),

--- a/src/main/java/org/sopt/global/code/status/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/status/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode implements BaseCode {
   EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 이메일입니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4001", "유효하지 않은 Refresh Token입니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH4002", "권한이 없습니다."),
-  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4003", "잘못된 비밀번호입니다.");
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4003", "잘못된 비밀번호입니다."),
+  SOCIAL_LOGIN_USER(HttpStatus.BAD_REQUEST, "AUTH4004", "소셜 로그인으로 가입된 계정입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/org/sopt/global/code/status/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/status/ErrorCode.java
@@ -12,7 +12,10 @@ public enum ErrorCode implements BaseCode {
   TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "POST4003", "제목은 필수입니다."),
   TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "POST4004", "게시글 제목은 50자 이하로 입력해주세요."),
   CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "POST4005", "내용은 필수입니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을 수 없습니다.");
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을 수 없습니다."),
+  EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 이메일입니다."),
+  INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4001", "유효하지 않은 Refresh Token입니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH4002", "권한이 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/org/sopt/global/code/status/ErrorCode.java
+++ b/src/main/java/org/sopt/global/code/status/ErrorCode.java
@@ -15,7 +15,8 @@ public enum ErrorCode implements BaseCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을 수 없습니다."),
   EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4002", "이미 존재하는 이메일입니다."),
   INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4001", "유효하지 않은 Refresh Token입니다."),
-  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH4002", "권한이 없습니다.");
+  FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH4002", "권한이 없습니다."),
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4003", "잘못된 비밀번호입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package org.sopt.global.exception;
 import org.sopt.dto.response.ApiResponse;
 import org.sopt.global.code.status.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,5 +22,12 @@ public class GlobalExceptionHandler {
     ErrorCode errorCode = e.getErrorCode();
     return ResponseEntity.status(errorCode.getHttpStatus())
         .body(ApiResponse.onFailure(errorCode, null));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException e
+  ) {
+    return ResponseEntity.status(ErrorCode.BAD_REQUEST.getHttpStatus()).body(ApiResponse.onFailure(ErrorCode.BAD_REQUEST, null));
   }
 }

--- a/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
+++ b/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
@@ -1,10 +1,10 @@
 package org.sopt.repository;
 
 import java.time.LocalDateTime;
-import org.sopt.domain.BlackListedAccessToken;
+import org.sopt.domain.BlacklistedAccessToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BlacklistedAccessTokenRepository extends JpaRepository<BlackListedAccessToken, Long> {
+public interface BlacklistedAccessTokenRepository extends JpaRepository<BlacklistedAccessToken, Long> {
   boolean existsByToken(String token);
   void deleteByExpiresAtBefore(LocalDateTime now);
 }

--- a/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
+++ b/src/main/java/org/sopt/repository/BlacklistedAccessTokenRepository.java
@@ -1,0 +1,10 @@
+package org.sopt.repository;
+
+import java.time.LocalDateTime;
+import org.sopt.domain.BlackListedAccessToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlacklistedAccessTokenRepository extends JpaRepository<BlackListedAccessToken, Long> {
+  boolean existsByToken(String token);
+  void deleteByExpiresAtBefore(LocalDateTime now);
+}

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);  // 메서드 이름으로 쿼리 자동 생성
   Optional<User> findById(Long id);
+  Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -12,6 +12,7 @@ import org.sopt.global.exception.GeneralException;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,16 +22,17 @@ public class AuthService {
   private final UserRepository userRepository;
   private final RefreshTokenRepository refreshTokenRepository;
   private final JwtService jwtService;
+  private final PasswordEncoder passwordEncoder;
 
   @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
   private long refreshTokenExpiresInSeconds;
 
   public UserResponse loginWithCredentials(String email, String password) {
     User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-    if (!user.getPassword().equals(password)) {
-      throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+    if (!passwordEncoder.matches(password, user.getPassword())) {
+      throw new GeneralException(ErrorCode.INVALID_PASSWORD);
     }
 
     return UserResponse.from(user);
@@ -58,7 +60,7 @@ public class AuthService {
       throw new GeneralException(ErrorCode.EMAIL_ALREADY_EXISTS);
     });
 
-    User user = new User(request.nickname(), request.email(), request.password());
+    User user = new User(request.nickname(), request.email(), passwordEncoder.encode(request.password()));
 
     return UserResponse.from(userRepository.save(user));
   }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,7 +1,9 @@
 package org.sopt.service;
 
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.sopt.domain.BlacklistedAccessToken;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.request.SignUpRequest;
@@ -9,6 +11,7 @@ import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
 import org.sopt.global.code.status.ErrorCode;
 import org.sopt.global.exception.GeneralException;
+import org.sopt.repository.BlacklistedAccessTokenRepository;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +26,7 @@ public class AuthService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final JwtService jwtService;
   private final PasswordEncoder passwordEncoder;
+  private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
 
   @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
   private long refreshTokenExpiresInSeconds;
@@ -87,5 +91,14 @@ public class AuthService {
     savedToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
 
     return TokenResponse.of(newAccessToken, newRefreshToken);
+  }
+
+  @Transactional
+  public void logout(Long userId, String accessToken) {
+    refreshTokenRepository.deleteByUserId(userId);
+
+    LocalDateTime expiresAt = jwtService.getExpiration(accessToken);
+
+    blacklistedAccessTokenRepository.save(BlacklistedAccessToken.of(accessToken, userId, expiresAt));
   }
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -4,8 +4,11 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
+import org.sopt.dto.request.SignUpRequest;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
+import org.sopt.global.code.status.ErrorCode;
+import org.sopt.global.exception.GeneralException;
 import org.sopt.repository.RefreshTokenRepository;
 import org.sopt.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,9 +52,38 @@ public class AuthService {
     return TokenResponse.of(accessToken, refreshToken);
   }
 
+  @Transactional
+  public UserResponse signUp(SignUpRequest request) {
+    userRepository.findByEmail(request.email()).ifPresent(user -> {
+      throw new GeneralException(ErrorCode.EMAIL_ALREADY_EXISTS);
+    });
+
+    User user = new User(request.nickname(), request.email(), request.password());
+
+    return UserResponse.from(userRepository.save(user));
+  }
+
   public UserResponse getUserById(Long userId) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
     return UserResponse.from(user);
+  }
+
+  @Transactional
+  public TokenResponse reissue(String refreshToken) {
+    RefreshToken savedToken = refreshTokenRepository.findByToken(refreshToken)
+        .orElseThrow(() -> new GeneralException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+    Long userId = jwtService.verifyAndGetUserId(refreshToken);
+
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+
+    String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+    String newRefreshToken = jwtService.generateRefreshToken(user.getId());
+
+    savedToken.rotate(newRefreshToken, refreshTokenExpiresInSeconds);
+
+    return TokenResponse.of(newAccessToken, newRefreshToken);
   }
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -3,10 +3,13 @@ package org.sopt.service;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.sopt.config.KakaoClient;
 import org.sopt.domain.BlacklistedAccessToken;
 import org.sopt.domain.RefreshToken;
 import org.sopt.domain.User;
 import org.sopt.dto.request.SignUpRequest;
+import org.sopt.dto.response.KakaoTokenResponse;
+import org.sopt.dto.response.KakaoUserInfoResponse;
 import org.sopt.dto.response.TokenResponse;
 import org.sopt.dto.response.UserResponse;
 import org.sopt.global.code.status.ErrorCode;
@@ -27,6 +30,7 @@ public class AuthService {
   private final JwtService jwtService;
   private final PasswordEncoder passwordEncoder;
   private final BlacklistedAccessTokenRepository blacklistedAccessTokenRepository;
+  private final KakaoClient kakaoClient;
 
   @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}")
   private long refreshTokenExpiresInSeconds;
@@ -64,7 +68,7 @@ public class AuthService {
       throw new GeneralException(ErrorCode.EMAIL_ALREADY_EXISTS);
     });
 
-    User user = new User(request.nickname(), request.email(), passwordEncoder.encode(request.password()));
+    User user = new User(request.nickname(), request.email(), passwordEncoder.encode(request.password()), null, null);
 
     return UserResponse.from(userRepository.save(user));
   }
@@ -100,5 +104,29 @@ public class AuthService {
     LocalDateTime expiresAt = jwtService.getExpiration(accessToken);
 
     blacklistedAccessTokenRepository.save(BlacklistedAccessToken.of(accessToken, userId, expiresAt));
+  }
+
+  @Transactional
+  public TokenResponse kakaoLogin(String code) {
+    KakaoTokenResponse kakaoToken = kakaoClient.getToken(code);
+    KakaoUserInfoResponse kakaoUser = kakaoClient.getUserInfo(kakaoToken.accessToken());
+
+    String provider = "KAKAO";
+    String providerId = String.valueOf(kakaoUser.id());
+    String email = kakaoUser.kakaoAccount().email();
+    String nickname = kakaoUser.properties().nickname();
+
+    User user = userRepository.findByProviderAndProviderId(provider, providerId)
+        .orElseGet(() -> userRepository.save(new User(nickname, email, null, provider, providerId)));
+
+    String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
+    String refreshToken = jwtService.generateRefreshToken(user.getId());
+
+    refreshTokenRepository.deleteByUserId(user.getId());
+    refreshTokenRepository.save(
+        RefreshToken.of(user.getId(), refreshToken, refreshTokenExpiresInSeconds)
+    );
+
+    return TokenResponse.of(accessToken, refreshToken);
   }
 }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -39,6 +39,10 @@ public class AuthService {
     User user = userRepository.findByEmail(email)
         .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
+    if (user.getProvider() != null) {
+      throw new GeneralException(ErrorCode.SOCIAL_LOGIN_USER);
+    }
+
     if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new GeneralException(ErrorCode.INVALID_PASSWORD);
     }

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -68,7 +68,11 @@ public class AuthService {
       throw new GeneralException(ErrorCode.EMAIL_ALREADY_EXISTS);
     });
 
-    User user = new User(request.nickname(), request.email(), passwordEncoder.encode(request.password()), null, null);
+    User user = User.builder()
+        .nickname(request.nickname())
+        .email(request.email())
+        .password(passwordEncoder.encode(request.password()))
+        .build();
 
     return UserResponse.from(userRepository.save(user));
   }
@@ -117,7 +121,12 @@ public class AuthService {
     String nickname = kakaoUser.properties().nickname();
 
     User user = userRepository.findByProviderAndProviderId(provider, providerId)
-        .orElseGet(() -> userRepository.save(new User(nickname, email, null, provider, providerId)));
+        .orElseGet(() -> userRepository.save(User.builder()
+            .nickname(nickname)
+            .email(email)
+            .provider(provider)
+            .providerId(providerId)
+            .build()));
 
     String accessToken = jwtService.generateAccessToken(user.getId(), user.getEmail());
     String refreshToken = jwtService.generateRefreshToken(user.getId());

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -57,7 +57,7 @@ public class JwtService {
     }
   }
 
-  public LocalDateTime getExpiresAt(String token) {
+  public LocalDateTime getExpiration(String token) {
     DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
     return jwt.getExpiresAt()
         .toInstant()

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -17,8 +17,8 @@ public class JwtService {
 
   public JwtService(
       @Value("${security.jwt.secret}") String secret,
-      @Value("${security.jwt.access-token-expires-in-seconds:1800}") long accessTokenExpiresInSeconds,
-      @Value("${security.jwt.refresh-token-expires-in-seconds:1209600}") long refreshTokenExpiresInSeconds
+      @Value("${security.jwt.access-token-expiration:1800}") long accessTokenExpiresInSeconds,
+      @Value("${security.jwt.refresh-token-expiration:1209600}") long refreshTokenExpiresInSeconds
   ) {
     this.algorithm = Algorithm.HMAC256(secret);
     this.accessTokenExpiresInSeconds = accessTokenExpiresInSeconds;

--- a/src/main/java/org/sopt/service/JwtService.java
+++ b/src/main/java/org/sopt/service/JwtService.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -54,5 +55,13 @@ public class JwtService {
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException("JWT의 회원 정보가 올바르지 않습니다.");
     }
+  }
+
+  public LocalDateTime getExpiresAt(String token) {
+    DecodedJWT jwt = JWT.require(algorithm).build().verify(token);
+    return jwt.getExpiresAt()
+        .toInstant()
+        .atZone(java.time.ZoneId.systemDefault())
+        .toLocalDateTime();
   }
 }

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -1,5 +1,7 @@
 package org.sopt.service;
 
+import java.util.Optional;
+import javax.swing.text.html.Option;
 import org.sopt.domain.Like;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
@@ -34,13 +36,15 @@ public class LikeService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-    Like like = likeRepository.findByUserIdAndPostId(userId, postId)
-        .orElseGet(() -> likeRepository.save(Like.builder()
+    Optional<Like> existingLike = likeRepository.findByUserIdAndPostId(userId, postId);
+    Like like = existingLike.orElseGet(() -> likeRepository.save(
+        Like.builder()
             .user(user)
             .post(post)
-            .build()));
+            .build()
+    ));
 
-    if (like.getId() != null) {
+    if (existingLike.isPresent()) {
       like.toggle();
     }
 

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -35,7 +35,10 @@ public class LikeService {
         .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
     Like like = likeRepository.findByUserIdAndPostId(userId, postId)
-        .orElseGet(() -> likeRepository.save(new Like(user, post)));
+        .orElseGet(() -> likeRepository.save(Like.builder()
+            .user(user)
+            .post(post)
+            .build()));
 
     if (like.getId() != null) {
       like.toggle();

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -75,7 +75,7 @@ public class PostService {
     if (start >= totalElements) {
       postResponses = List.of();
     } else {
-      postResponses = posts.subList(start, end).stream().map(PostResponse::new).toList();
+      postResponses = posts.subList(start, end).stream().map(PostResponse::from).toList();
     }
 
     return new PostListResponse(postResponses, postResponses.size(), totalPages, totalElements, page == 0, page >= totalPages - 1);
@@ -86,7 +86,7 @@ public class PostService {
     PostValidator.validatePostId(id);
     Post post = postRepository.findById(id)
         .orElseThrow(PostNotFoundException::new);
-    return new PostResponse(post);
+    return PostResponse.from(post);
   }
 
   @Transactional  // 변경 → 더티 체킹으로 save() 없이 자동 UPDATE
@@ -101,7 +101,7 @@ public class PostService {
     }
 
     post.update(request.title(), request.content(), request.isQuestion(), request.isAnonymous()); // save() 호출 없어도 트랜잭션 커밋 시 UPDATE 쿼리 자동 실행
-    return new PostResponse(post);
+    return PostResponse.from(post);
   }
 
   // DELETE 📝 과제
@@ -114,7 +114,7 @@ public class PostService {
       throw new GeneralException(ErrorCode.FORBIDDEN);
     }
 
-    PostResponse response = new PostResponse(post);
+    PostResponse response = PostResponse.from(post);
     postRepository.delete(post);
     return response;
   }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -32,10 +32,10 @@ public class PostService {
   }
 
   @Transactional  // 저장 → DB 변경 발생 → 트랜잭션 커밋 시 반영
-  public CreatePostResponse createPost(CreatePostRequest request) {
+  public CreatePostResponse createPost(CreatePostRequest request, Long userId) {
     PostValidator.validatePostTitle(request.title());
 
-    User user = userRepository.findById(request.userId())
+    User user = userRepository.findById(userId)
         .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
     Post post = new Post(request.title(), request.content(), user, request.isQuestion(), request.isAnonymous(), request.boardType());
@@ -83,11 +83,15 @@ public class PostService {
   }
 
   @Transactional  // 변경 → 더티 체킹으로 save() 없이 자동 UPDATE
-  public PostResponse updatePost(Long id, UpdatePostRequest request) {
+  public PostResponse updatePost(Long id, UpdatePostRequest request, Long userId) {
     PostValidator.validatePostTitle(request.title());
 
     Post post = postRepository.findById(id)
         .orElseThrow(PostNotFoundException::new);
+
+    if (!post.getUser().getId().equals(userId)) {
+      throw new GeneralException(ErrorCode.FORBIDDEN);
+    }
 
     post.update(request.title(), request.content(), request.isQuestion(), request.isAnonymous()); // save() 호출 없어도 트랜잭션 커밋 시 UPDATE 쿼리 자동 실행
     return new PostResponse(post);
@@ -95,9 +99,14 @@ public class PostService {
 
   // DELETE 📝 과제
   @Transactional
-  public PostResponse deletePost(Long id) {
+  public PostResponse deletePost(Long id, Long userId) {
     Post post = postRepository.findById(id)
         .orElseThrow(PostNotFoundException::new);
+
+    if (!post.getUser().getId().equals(userId)) {
+      throw new GeneralException(ErrorCode.FORBIDDEN);
+    }
+
     PostResponse response = new PostResponse(post);
     postRepository.delete(post);
     return response;

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -38,7 +38,14 @@ public class PostService {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-    Post post = new Post(request.title(), request.content(), user, request.isQuestion(), request.isAnonymous(), request.boardType());
+    Post post = Post.builder()
+        .title(request.title())
+        .content(request.content())
+        .user(user)
+        .isQuestion(request.isQuestion())
+        .isAnonymous(request.isAnonymous())
+        .boardType(request.boardType())
+        .build();
     postRepository.save(post);
     return new CreatePostResponse(post.getId(), "게시글 등록 완료!");
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,10 @@ security:
     secret: ${JWT_SECRET}
     access-token-expiration: 1800 # 30 minutes
     refresh-token-expiration: 1209600 # 14 days
+oauth:
+  kakao:
+    client-id: ${KAKAO_REST_API_KEY}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: http://localhost:8080/api/v1/auth/kakao/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
# 🔥*Pull requests*
closed #14 


## 👷 **과제 구현**

### 필수과제
- [x] 오늘 실습한 JWT + Spring Security 인증을 에브리타임 클론 프로젝트 전체에 적용해주세요. 로그인/토큰 재발급 API는 인증 없이 접근 가능하고, 게시글 작성/수정/삭제, 좋아요 추가/취소는 인증이 필요하도록 설정해주세요.
- [x] 비밀번호를 평문으로 저장하는 건 위험해요. BCryptPasswordEncoder를 사용해서 비밀번호를 암호화해서 저장하고, 로그인 시 matches()로 검증하도록 수정해주세요.

<br>

### 선택과제
- [x] 로그아웃 API를 구현해주세요. 로그아웃 시 DB에서 해당 유저의 Refresh Token을 삭제하고, 현재 Access Token을 블랙리스트에 추가해서 만료 전에도 사용할 수 없도록 해주세요. Access Token이 만료됐을 때 클라이언트가 어떻게 401을 감지해서 로그인 페이지로 이동시킬지 흐름도 함께 작성해주세요.
- [x] Kakao 또는 Google OAuth 2.0 소셜 로그인을 구현해주세요. 외부 인증 서버로부터 유저 정보를 받아온 후, 우리 서버에서 JWT(Access Token + Refresh Token)를 발급하는 흐름까지 완성해주세요. 신규 유저라면 자동으로 회원가입 처리하고, 기존 유저라면 로그인 처리해주세요.

<br>

### **구현한 내용에 대해서 설명해주세요**
- JWT와 Spring Security를 적용해 인증이 필요한 API와 인증 없이 접근 가능한 API를 분리했습니다.
- 로그인 성공 시 Access Token과 Refresh Token을 함께 발급하고, Refresh Token은 DB에 저장했습니다. 토큰 재발급 요청 시 전달받은 Refresh Token이 DB에 존재하는지 확인한 뒤, 새로운 Access Token과 Refresh Token을 발급하도록 구현했습니다.
- 게시글 작성/수정/삭제와 좋아요 처리 시 인증된 JWT에서 꺼낸 사용자 ID를 사용하도록 수정했습니다.
- 비밀번호는 BCryptPasswordEncoder를 사용해 암호화하여 저장하도록 변경했고, 로그인 시에는 `matches()`를 사용해 입력된 평문 비밀번호와 DB에 저장된 암호화 비밀번호를 비교하도록 수정했습니다.
- Swagger에서도 JWT 인증을 테스트할 수 있도록 Bearer 인증 설정을 추가했습니다.
- 요청 DTO에 Bean Validation을 적용하고, 엔티티 생성 로직은 빌더 패턴으로 정리했습니다.

<br>


### **구현하며 고민했던 내용을 적어주세요 (사소한 것도 좋아요)**
처음에는 로그아웃 시 Refresh Token만 삭제하면 되는 거 아닌가?라는 생각이 들어서 찾아보니 Access Token은 자체적으로 만료 전까지 유효하기 때문에 특히 보안이 중요한 서비스나 즉시 로그아웃 처리가 필요한 경우에는 현재 사용 중인 Access Token도 함께 무효화해야 하기 때문에 블랙리스트 방식을 사용한다는 점을 알게 되었습니다.

추가적으로 블랙리스트를 어떤 방식으로 관리할지도 고민했습니다. Redis를 이용해 TTL 기반으로 관리하는 방식이나 JWT의 jti 값을 활용하는 방식 등 여러 방법이 있었는데, 이번 과제에서는 구현 복잡도와 현재 프로젝트 규모를 고려하여 DB의 블랙리스트 테이블을 통해 관리하는 방식으로 구현했습니다.

<br>

---
### **키워드 과제 정리내용**
<details>
<summary>OAuth 2.0이란 무엇인가요? 인증 흐름을 정리해보세요.</summary>
OAuth 2.0은 비밀번호를 직접 넘기지 않고도 내 데이터에 접근할 수 있게 해주는 인가 프레임워크다.
 
예를 들어 어떤 앱에서 "Google로 로그인"을 누를 때, 그 앱에 Google 비밀번호를 알려주는 게 아니라 Google이 "이 앱한테 이 정도 권한 줘도 돼?" 하고 나한테 물어보고, 내가 OK 하면 토큰을 발급해주는 방식이다.
 
---
 
**구성 요소** 
- **Resource Owner**: 내 데이터의 진짜 주인. 보통 사용자(나)를 뜻한다.
- **Client** — 내 데이터에 접근하고 싶어하는 제3자 앱. (예: 캘린더 연동 앱)
- **Authorization Server**: 나를 인증하고 토큰을 발급해주는 서버. Google, Kakao 같은 플랫폼이 이 역할을 한다.
- **Resource Server**: 실제로 보호된 데이터를 들고 있는 API 서버.
 
---
 
**인가 흐름 (Grant Types)**
 
<details>
<summary>Authorization Code Grant — 가장 일반적이고 안전한 방식</summary>
서버 사이드 웹 앱에서 주로 쓴다.
 
1. 사용자가 "Google로 로그인" 버튼을 누른다.
2. Client 앱이 사용자를 Authorization Server 로그인 페이지로 리다이렉트시킨다.
3. 사용자가 로그인하고 "이 앱에 권한 줄게요" 동의를 누른다.
4. Authorization Server가 Client의 redirect URI로 **authorization code**를 보내준다.
5. Client는 이 code를 **백엔드에서** client_secret과 함께 Authorization Server에 보내서 Access Token으로 교환한다.
6. 받은 토큰으로 Resource Server에 API 요청을 날린다.
여기서 포인트는 **토큰 교환이 서버 간(back-channel)에서 일어난다**는 점이다. code는 브라우저를 거쳐 전달되지만, 정작 중요한 Access Token은 브라우저에 노출되지 않는다.
 
</details>
<details>
<summary>Authorization Code + PKCE — SPA/모바일용 확장</summary>
SPA나 모바일 앱은 client_secret을 코드에 넣어둘 수가 없다. (클라이언트 쪽 코드는 누구나 볼 수 있으므로!!)
 
그래서 PKCE라는 걸 추가했다:
1. Client가 랜덤 문자열 **code_verifier**를 만든다.
2. 이걸 해시한 **code_challenge**를 인가 요청에 같이 보낸다.
3. 나중에 토큰 교환할 때 원본 code_verifier를 제출하면, 서버가 해시를 비교해서 "아 진짜 처음에 요청한 애가 맞구나" 확인한다.
client_secret 없이도 authorization code 탈취 공격을 막을 수 있는 방식이다.
 
</details>
<details>
<summary>Client Credentials Grant — 서버 대 서버 통신</summary>
사용자가 끼어들 필요 없는 M2M(Machine-to-Machine) 통신용이다.
 
Client가 자기 client_id와 client_secret만으로 바로 토큰을 발급받는다. 백엔드 배치 작업이 내부 API를 호출하는 경우 같은 데 쓴다.
 
</details>
---
 
**흐름(Authorization Code Grant)**
 
```
사용자 → Client 앱          "로그인할래요"
Client 앱 → 인가 서버        인가 요청 리다이렉트 (client_id, redirect_uri, scope)
인가 서버 → 사용자           로그인 + 동의 화면
사용자 → 인가 서버           "허용"
인가 서버 → Client 앱        Authorization Code 전달
Client 앱 → 인가 서버        Code + client_secret 보내서 Token 교환 (back-channel)
인가 서버 → Client 앱        Access Token + Refresh Token 발급
Client 앱 → 리소스 서버      API 요청 (Authorization: Bearer {token})
리소스 서버 → Client 앱      보호된 데이터 응답
```
 
---
 
결국 OAuth 2.0의 핵심은 "비밀번호 대신 토큰을 쓰자"는 것이다. 내 비밀번호는 인가 서버만 알고 있고, 제3자 앱은 제한된 권한의 토큰만 받아서 필요한 데이터에 접근한다. 덕분에 특정 앱의 접근만 따로 끊을 수도 있고, 비밀번호를 바꿀 필요도 없다.
</details>
<br>

---

## 🚨 참고 사항

<details>
<summary>Access Token 만료 시 클라이언트 처리 흐름</summary>

클라이언트가 인증이 필요한 API를 호출할 때, `Authorization` 헤더에 Access Token을 담아서 보낸다.

```http
Authorization: Bearer {accessToken}
```

서버 쪽에서는 JWT 인증 필터가 이 토큰을 검증하는데, 만료됐거나 유효하지 않으면 **401 Unauthorized**를 내려준다.

1. API 요청 시 Access Token을 헤더에 담아 보낸다.
2. 서버가 JWT를 검증한다.
3. 토큰이 유효하면 정상 응답
4. 만료/유효하지 않으면 401 응답
5. 클라이언트 인터셉터가 401을 감지한다.
6. 저장해둔 Access Token, Refresh Token을 삭제한다.
7. 사용자를 로그인 페이지로 이동시킨다.